### PR TITLE
Fix foursight core wfr utils issue

### DIFF
--- a/chalicelib/checks/helpers/wfr_utils.py
+++ b/chalicelib/checks/helpers/wfr_utils.py
@@ -2,14 +2,11 @@ import json
 from datetime import datetime
 from operator import itemgetter
 from dcicutils import ff_utils, s3Utils
-from foursight_core.checks.helpers.wfr_utils import (
-    lambda_limit,
-    check_runs_without_output
-)
 from .wfrset_utils import (
     # use wf_dict in workflow version check to make sure latest version and workflow uuid matches
     wf_dict,
-    step_settings 
+    step_settings,
+    lambda_limit
 )
 
 
@@ -922,6 +919,62 @@ def find_fastq_info(my_sample, fastq_files, organism='human'):
             'bwa_ref': bwa,
             'f_size': str(f_size)+'GB'}
     return files, refs
+
+
+def check_runs_without_output(res, check, run_name, my_auth, start):
+    """Common processing for checks that are running on files and not producing output files
+    like qcs ones producing extra files"""
+    # no successful run
+    missing_run = []
+    # successful run but no expected metadata change (qc or extra file)
+    missing_meta_changes = []
+    # still running
+    running = []
+    # multiple failed runs
+    problems = []
+
+    for a_file in res:
+        # lambda has a time limit (300sec), kill before it is reached so we get some results
+        now = datetime.utcnow()
+        if (now-start).seconds > lambda_limit:
+            check.brief_output.append('did not complete checking all')
+            break
+        file_id = a_file['accession']
+        report = get_wfr_out(a_file, run_name,  key=my_auth, md_qc=True)
+        if report['status'] == 'running':
+            running.append(file_id)
+        elif report['status'].startswith("no complete run, too many"):
+            problems.append(file_id)
+        elif report['status'] != 'complete':
+            missing_run.append(file_id)
+        # There is a successful run, but not the expected change (should be part of query)
+        elif report['status'] == 'complete':
+            missing_meta_changes.append(file_id)
+    if running:
+        check.summary = 'Some files are running'
+        check.brief_output.append(str(len(running)) + ' files are still running.')
+        check.full_output['running'] = running
+    if problems:
+        check.summary = 'Some files have problems'
+        check.brief_output.append(str(len(problems)) + ' files have multiple failed runs')
+        check.full_output['problems'] = problems
+        check.status = 'WARN'
+    if missing_run:
+        check.allow_action = True
+        check.summary = 'Some files are missing runs'
+        check.brief_output.append(str(len(missing_run)) + ' files lack a successful run')
+        check.full_output['files_without_run'] = missing_run
+        check.status = 'WARN'
+    if missing_meta_changes:
+        check.allow_action = True
+        check.summary = 'Some files are missing runs'
+        check.brief_output.append(str(len(missing_meta_changes)) + ' files have successful run but no qc/extra file')
+        check.full_output['files_without_changes'] = missing_meta_changes
+        check.status = 'WARN'
+    check.summary = check.summary.strip()
+    if not check.brief_output:
+        check.brief_output = ['All Good!']
+    return check
 
 
 def start_tasks(missing_runs, patch_meta, action, my_auth, my_env, start, move_to_pc=False, runtype='hic'):

--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -1,3 +1,6 @@
+# lambda limit
+lambda_limit = 800
+
 # Step Settings
 mapper = {'human': 'GRCh38',
           'mouse': 'GRCm38',

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -1,13 +1,9 @@
 import json
 from datetime import datetime
 from dcicutils import ff_utils, s3Utils
-from foursight_core.checks.helpers.wfr_utils import (
-    check_runs_without_output,
-    lambda_limit
-)
 from .helpers import wfr_utils
 from .helpers.wfrset_utils import step_settings
-
+from .helpers.wfrset_utils import lambda_limit
 # Use confchecks to import decorators object and its methods for each check module
 # rather than importing check_function, action_function, CheckResult, ActionResult
 # individually - they're now part of class Decorators in foursight-core::decorators
@@ -228,7 +224,7 @@ def fastqcCGAP_status(connection, **kwargs):
     if not res:
         check.summary = 'All Good!'
         return check
-    check = check_runs_without_output(res, check, 'fastqc', my_auth, start)
+    check = wfr_utils.check_runs_without_output(res, check, 'fastqc', my_auth, start)
     return check
 
 
@@ -1414,7 +1410,7 @@ def bamqcCGAP_status(connection, **kwargs):
         check.summary = 'All Good!'
         return check
 
-    check = check_runs_without_output(res, check, 'workflow_qcboard-bam', my_auth, start)
+    check = wfr_utils.check_runs_without_output(res, check, 'workflow_qcboard-bam', my_auth, start)
     return check
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "0.3.3"
+version = "0.3.4"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
foursight_core.checks.helpers.wfr_utils was removed from the foursight-core repo because it cannot be used by 4DN and CGAP.

-Added the check_runs_without_output function and lambda limit variable that used to be imported from fousight-core
-updated all the places they were used.