### PR TITLE
Clone case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ htmlcov/
 coverage.xml
 *.ipynb
 !*LocalTest.ipynb
+.python-version
 requirements.txt
 
 # Virtual environments

--- a/chalicelib/checks/helpers/clone_utils.py
+++ b/chalicelib/checks/helpers/clone_utils.py
@@ -1,0 +1,108 @@
+# 1. case -> get SampleProcessing
+# 2. clone samples, patch to individuals
+# 3. clone cases, add new Sample + SP items
+
+
+class CaseToClone:
+
+    keep_fields = ['project', 'institution']
+    remove_fields = ['uuid', 'submitted_by', 'last_modified', 'schema_version', 'date_created', 'accession']
+
+    def __init__(self, accession, key, new_version):
+        self.accession = accession
+        self.key = key
+        self.case_metadata = self.get_case_metadata()
+        self.old_sample_processing = self.metadata.get('sample_processing')
+        self.sp_metadata = self.get_sp_metadata()
+        # self.old_title = self.metadata.get('case_title')
+        # self.new_title = self.old_title + f' ({new_version})'
+        self.old_samples = self.sp_metadata.get('samples')
+        self.sample_info = self.clone_samples()
+        self.patch_individual_samples()
+        self.new_sp_item = self.clone_sample_processing()
+
+    def get_case_metadata(self):
+        return ff_utils.get_metadata(self.accession + '?frame=raw', key=self.key)
+
+    def get_sp_metadata(self):
+        if self.old_sample_processing:
+            return ff_utils.get_metadata(self.old_sample_processing + '?frame=object', key=self.key)
+
+    def clone_samples(self):
+        # remove_fields_sample = ['individual']
+        results = []
+        for item in self.old_samples:
+            try:
+                resp = ff_utils.get_metadata(sample + '?frame=object', key=self.key)
+            except Exception:
+                pass
+            else:
+                results.append(resp)
+        sample_info = {}
+        for result in results:
+            sample_info[result['@id']] = {}
+            sample_info[result['@id']]['individual'] = result.get('individual')
+            for field in remove_fields + remove_fields_sample:
+                if field in result:
+                    del result[field]
+            # change title? bam_sample_id? etc?
+            try:
+                post_resp = ff_utils.post_metadata(result, 'sample', key=self.key)
+            except Exception:
+                pass
+            else:
+                sample_info[result['@id']]['new_id'] = post_resp['@id']
+        return sample_info
+
+    def patch_individual_samples(self):
+        for v in self.sample_info.items():
+            try:
+                individual_metadata = ff_utils.get_metadata(v['individual'], key=self.key)
+            except Exception:
+                continue
+            try:
+                sample_patch = {'samples': individual_metadata.get('samples', []) + [v['new_id']]}
+                resp = ff_utils.patch_metadata(sample_patch, k, key=self.key)
+            except Exception:
+                pass
+
+    def clone_sample_processing(self):
+        keep_fields_sp = ['analysis_type', 'families']
+        new_sp_metadata = {}
+        for item in keep_fields + keep_fields_sp:
+            new_sp_metadata[item] = self.sp_metadata[item]
+        new_sp_metadata['samples'] = [item['new_id'] for item in self.sample_info.values()]
+        # might need to add back some processed files, etc if pipeline is only being rerun at a particular step
+        try:
+            resp = ff_utils.post_metadata(new_sp_metadata, 'sample_processing', key=self.key)
+        except Exception:
+            pass
+        return resp['@id']
+
+    def clone_cases(self):
+        keep_fields_case = [
+            'family', 'individual', 'description', 'extra_variant_sample_facets', 'active_filterset'
+        ]
+        cases = self.sp_metadata.get('cases')
+        new_cases = []
+        for case in cases:
+            try:
+                old_case_metadata = ff_utils.get_metadata(case, key=self.key)
+            except Exception:
+                continue
+            new_case_metadata = {}
+            for field in keep_fields + keep_fields_case:
+                new_case_metadata[field] = old_case_metadata.get(field)
+            new_case_metadata['sample_processing'] = self.new_sp_item
+            old_case_id = old_case_metadata.get('case_id')
+            if old_case_id:
+                if old_case_id.endswith(''):
+                    pass
+            new_case_metadata['case_id'] = None
+            try:
+                post_resp = ff_utils.post_metadata(new_case_metadata, 'case', key=self.key)
+            except Exception:
+                continue
+            new_cases.append(post_resp['@id'])
+
+    # something for meta-workflow-run

--- a/chalicelib/checks/helpers/clone_utils.py
+++ b/chalicelib/checks/helpers/clone_utils.py
@@ -15,6 +15,7 @@ class CaseToClone:
         self.accession = accession
         self.key = key
         self.new_version = new_version
+        self.errors = []
         self.case_metadata = self.get_case_metadata()
         self.old_sample_processing = self.case_metadata.get('sample_processing')
         self.sp_metadata = self.get_sp_metadata()
@@ -25,10 +26,12 @@ class CaseToClone:
         self.new_cases = self.clone_cases()
 
     def append_version_to_value(self, value):
+        if value is None:
+            return
         if isinstance(value, list):
-            return [self.append_version_to_value(item) for item in value]
+            return [self.append_version_to_value(item) for item in value if item]
         new_value = re.sub(pattern, '', value)
-        new_value = new_value + '-v' + self.new_version
+        return new_value + '-v' + self.new_version
 
     def get_case_metadata(self):
         return ff_utils.get_metadata(self.accession + '?frame=raw', key=self.key)
@@ -38,13 +41,14 @@ class CaseToClone:
             return ff_utils.get_metadata(self.old_sample_processing + '?frame=object', key=self.key)
 
     def clone_samples(self):
+        # need to remove processed_files, completed_processes?
+        # remove_fields_sample = []
         results = []
         for sample in self.old_samples:
             try:
-                print('1')
                 resp = ff_utils.get_metadata(sample + '?frame=raw', key=self.key)
             except Exception as e:
-                print(e)
+                self.errors.append(e)
             else:
                 results.append(resp)
         sample_info = {}
@@ -52,35 +56,37 @@ class CaseToClone:
         search_url = f'search/?type=Sample&uuid={"&uuid=".join(sample_ids)}&field=individual&frame=object'
         sample_individual_search = ff_utils.search_metadata(search_url, key=self.key)
         for search_result in sample_individual_search:
-            print(search_result)
             sample_info[search_result['@id']] = {'individual': search_result['individual']['@id']}
-        print(results)
         for result in results:
+            old_accession = result['accession']
             for field in self.remove_fields:
                 if field in result:
                     del result[field]
             # change title? bam_sample_id? etc?
             for field in ['bam_sample_id', 'aliases']:
-                result[field] = self.append_version_to_value(result[field])
+                if field in result:
+                    result[field] = self.append_version_to_value(result[field])
+            print(result)
             try:
                 post_resp = ff_utils.post_metadata(result, 'sample', key=self.key)
             except Exception as e:
-                print(e)
+                self.errors.append(e)
             else:
-                sample_info[result['uuid']]['new_id'] = post_resp['@graph'][0]['@id']
+                sample_info[f'/samples/{old_accession}/']['new_id'] = post_resp['@graph'][0]['@id']
         return sample_info
 
     def patch_individual_samples(self):
-        for v in self.sample_info.items():
+        for v in self.sample_info.values():
             try:
-                individual_metadata = ff_utils.get_metadata(v['individual'], key=self.key)
-            except Exception:
+                individual_metadata = ff_utils.get_metadata(v['individual'] + '?frame=object', key=self.key)
+            except Exception as e:
+                self.errors.append(e)
                 continue
             try:
                 sample_patch = {'samples': individual_metadata.get('samples', []) + [v['new_id']]}
-                resp = ff_utils.patch_metadata(sample_patch, k, key=self.key)
-            except Exception:
-                pass
+                resp = ff_utils.patch_metadata(sample_patch, v['individual'], key=self.key)
+            except Exception as e:
+                self.errors.append(e)
 
     def clone_sample_processing(self):
         keep_fields_sp = ['analysis_type', 'families']
@@ -97,6 +103,7 @@ class CaseToClone:
             return resp['@graph'][0]['@id']
 
     def clone_cases(self):
+        # add report?
         keep_fields_case = [
             'family', 'individual', 'description', 'extra_variant_sample_facets', 'active_filterset', 'case_id'
         ]
@@ -106,7 +113,7 @@ class CaseToClone:
             try:
                 old_case_metadata = ff_utils.get_metadata(case + '?frame=object', key=self.key)
             except Exception as e:
-                print(e)
+                self.errors.append(e)
             new_case_metadata = {}
             for field in self.keep_fields + keep_fields_case:
                 if field in old_case_metadata:
@@ -116,7 +123,7 @@ class CaseToClone:
                 post_resp = ff_utils.post_metadata(new_case_metadata, 'case', key=self.key)
                 new_cases.append(post_resp['@graph'][0]['@id'])
             except Exception as e:
-                print(e)
+                self.errors.append(e)
 #             else:
 #                 new_cases.append(post_resp['@graph'][0]['@id'])
 

--- a/chalicelib/checks/helpers/clone_utils.py
+++ b/chalicelib/checks/helpers/clone_utils.py
@@ -4,7 +4,8 @@ from magma_ff import import_metawfr
 # still need to figure if we need to add processed files to sample, sample_processing
 # hold off on meta-wfrs for now?
 
-pattern = re.compile(r'-v[0-9]+$')
+pattern_nospace = re.compile(r'-v[0-9]+$')
+pattern_pretty = re.compile(r' \(v[0-9]+\)$')
 
 
 class CaseToClone:
@@ -39,16 +40,19 @@ class CaseToClone:
         self.patch_individual_samples()
         self.new_sp_item = self.clone_sample_processing()
         self.new_cases = self.clone_cases()
-        self.analysis_type = self.get_analysis_type()
+        # self.analysis_type = self.get_analysis_type()
         # if self.metawf_uuid:
-        #     self.meta_wfr = self.add_metawfr()
+        #    self.meta_wfr = self.add_metawfr()
 
-    def append_version_to_value(self, value):
+    def append_version_to_value(self, value, pretty=False):
         if value is None:
             return
         if isinstance(value, list):
             return [self.append_version_to_value(item) for item in value if item]
+        pattern = pattern_nospace if not pretty else pattern_pretty
         new_value = re.sub(pattern, '', value)
+        if pretty:
+            return new_value + f' (v{self.new_version})'
         return new_value + '-v' + self.new_version
 
     def try_request(self, func, *args, **kwargs):
@@ -137,6 +141,7 @@ class CaseToClone:
             if item in self.sp_metadata:
                 new_sp_metadata[item] = self.sp_metadata.get(item)
         new_sp_metadata['samples'] = [item['new_id'] for item in self.sample_info.values()]
+        new_sp_metadata['analysis_version'] = 'v' + str(self.new_version)
 
         # add back some processed files, etc if pipeline is only being rerun at a particular step
         if self.sp_metadata.get('processed_files'):
@@ -170,6 +175,19 @@ class CaseToClone:
                 if field in old_case_metadata:
                     new_case_metadata[field] = old_case_metadata.get(field)
             new_case_metadata['sample_processing'] = self.new_sp_item
+            if not 'case_id' in new_case_metadata:
+                new_case_metadata['case_id'] = old_case_metadata.get('case_title')
+            new_case_metadata['case_id'] = self.append_version_to_value(new_case_metadata['case_id'], pretty=True)
+
+            if old_case_metadata.get('report'):
+                new_report_json = {
+                    'project': old_case_metadata['project'],
+                    'institution': old_case_metadata['institution']
+                }
+                report = try_request(ff_utils.post_metadata, new_report_json, 'report', key=self.key)
+                if report:
+                    new_case_metadata['report'] = report['@graph'][0]['@id']
+
             post_resp = try_request(ff_utils.post_metadata, new_case_metadata, 'case', key=self.key)
             if post_resp:
                 new_cases.append(post_resp['@graph'][0]['@id'])
@@ -182,23 +200,23 @@ class CaseToClone:
         elif sp_type.endswith('Group'):
             # figure out if trio+ or if parents aren't present
             sample_relations = [item.get('relationship') for item in self.sp_metadata.get('samples_pedigree', [{}])]
-            if all(relation in sample_relations for item in ['proband', 'mother', 'father']):
+            if all(item in sample_relations for item in ['proband', 'mother', 'father']):
                 return 'trio'
         # if not yet returned, then it is a proband-only analysis
         if all(sample.get('cram_files') for sample in self.samples_metadata):
             return 'cram proband'
         return 'proband'
 
-    # def add_metawfr(self):
-    #     metawfr_json = import_metawfr.import_metawfr(
-    #         metawf_uuid=self.metawf_uuid,
-    #         metawfr_uuid=self.case_metadata['meta_workflow_run'],
-    #         case_uuid=self.case_metadata['uuid'],
-    #         steps_name=self.steps_to_rerun,
-    #         create_metawfr=create_metawfr.create_metawfr_from_case,
-    #         type=f'WGS {self.analysis_type}',
-    #         ff_key=self.key,
-    #         post=False,
-    #         verbose=False
-    #     )
-    #     return metawfr_json
+    def add_metawfr(self):
+        metawfr_json = import_metawfr.import_metawfr(
+            metawf_uuid=self.metawf_uuid,
+            metawfr_uuid=self.case_metadata['meta_workflow_run'],
+            case_uuid=self.case_metadata['uuid'],
+            steps_name=self.steps_to_rerun,
+            create_metawfr=create_metawfr.create_metawfr_from_case,
+            type=f'WGS {self.analysis_type}',
+            ff_key=self.key,
+            post=False,
+            verbose=False
+        )
+        return metawfr_json

--- a/chalicelib/checks/helpers/clone_utils.py
+++ b/chalicelib/checks/helpers/clone_utils.py
@@ -3,6 +3,9 @@
 # 3. clone cases, add new Sample + SP items
 # case title is a calc prop, should add version - prop in SP item?
 
+pattern = re.compile(r'-v[0-9]+$')
+
+
 class CaseToClone:
 
     keep_fields = ['project', 'institution']
@@ -13,12 +16,19 @@ class CaseToClone:
         self.key = key
         self.new_version = new_version
         self.case_metadata = self.get_case_metadata()
-        self.old_sample_processing = self.metadata.get('sample_processing')
+        self.old_sample_processing = self.case_metadata.get('sample_processing')
         self.sp_metadata = self.get_sp_metadata()
         self.old_samples = self.sp_metadata.get('samples')
         self.sample_info = self.clone_samples()
         self.patch_individual_samples()
         self.new_sp_item = self.clone_sample_processing()
+        self.new_cases = self.clone_cases()
+
+    def append_version_to_value(self, value):
+        if isinstance(value, list):
+            return [self.append_version_to_value(item) for item in value]
+        new_value = re.sub(pattern, '', value)
+        new_value = new_value + '-v' + self.new_version
 
     def get_case_metadata(self):
         return ff_utils.get_metadata(self.accession + '?frame=raw', key=self.key)
@@ -29,27 +39,35 @@ class CaseToClone:
 
     def clone_samples(self):
         results = []
-        for item in self.old_samples:
+        for sample in self.old_samples:
             try:
-                resp = ff_utils.get_metadata(sample + '?frame=object', key=self.key)
-            except Exception:
-                pass
+                print('1')
+                resp = ff_utils.get_metadata(sample + '?frame=raw', key=self.key)
+            except Exception as e:
+                print(e)
             else:
                 results.append(resp)
         sample_info = {}
+        sample_ids = [result['uuid'] for result in results]
+        search_url = f'search/?type=Sample&uuid={"&uuid=".join(sample_ids)}&field=individual&frame=object'
+        sample_individual_search = ff_utils.search_metadata(search_url, key=self.key)
+        for search_result in sample_individual_search:
+            print(search_result)
+            sample_info[search_result['@id']] = {'individual': search_result['individual']['@id']}
+        print(results)
         for result in results:
-            sample_info[result['@id']] = {}
-            sample_info[result['@id']]['individual'] = result.get('individual')
-            for field in remove_fields:
+            for field in self.remove_fields:
                 if field in result:
                     del result[field]
             # change title? bam_sample_id? etc?
+            for field in ['bam_sample_id', 'aliases']:
+                result[field] = self.append_version_to_value(result[field])
             try:
                 post_resp = ff_utils.post_metadata(result, 'sample', key=self.key)
-            except Exception:
-                pass
+            except Exception as e:
+                print(e)
             else:
-                sample_info[result['@id']]['new_id'] = post_resp['@id']
+                sample_info[result['uuid']]['new_id'] = post_resp['@graph'][0]['@id']
         return sample_info
 
     def patch_individual_samples(self):
@@ -67,7 +85,7 @@ class CaseToClone:
     def clone_sample_processing(self):
         keep_fields_sp = ['analysis_type', 'families']
         new_sp_metadata = {}
-        for item in keep_fields + keep_fields_sp:
+        for item in self.keep_fields + keep_fields_sp:
             new_sp_metadata[item] = self.sp_metadata[item]
         new_sp_metadata['samples'] = [item['new_id'] for item in self.sample_info.values()]
         # might need to add back some processed files, etc if pipeline is only being rerun at a particular step
@@ -75,7 +93,8 @@ class CaseToClone:
             resp = ff_utils.post_metadata(new_sp_metadata, 'sample_processing', key=self.key)
         except Exception:
             pass
-        return resp['@id']
+        else:
+            return resp['@graph'][0]['@id']
 
     def clone_cases(self):
         keep_fields_case = [
@@ -85,17 +104,20 @@ class CaseToClone:
         new_cases = []
         for case in cases:
             try:
-                old_case_metadata = ff_utils.get_metadata(case, key=self.key)
-            except Exception:
-                continue
+                old_case_metadata = ff_utils.get_metadata(case + '?frame=object', key=self.key)
+            except Exception as e:
+                print(e)
             new_case_metadata = {}
-            for field in keep_fields + keep_fields_case:
-                new_case_metadata[field] = old_case_metadata.get(field)
+            for field in self.keep_fields + keep_fields_case:
+                if field in old_case_metadata:
+                    new_case_metadata[field] = old_case_metadata.get(field)
             new_case_metadata['sample_processing'] = self.new_sp_item
             try:
                 post_resp = ff_utils.post_metadata(new_case_metadata, 'case', key=self.key)
-            except Exception:
-                continue
-            new_cases.append(post_resp['@id'])
+                new_cases.append(post_resp['@graph'][0]['@id'])
+            except Exception as e:
+                print(e)
+#             else:
+#                 new_cases.append(post_resp['@graph'][0]['@id'])
 
     # something for meta-workflow-run

--- a/chalicelib/checks/helpers/clone_utils.py
+++ b/chalicelib/checks/helpers/clone_utils.py
@@ -40,9 +40,9 @@ class CaseToClone:
         self.patch_individual_samples()
         self.new_sp_item = self.clone_sample_processing()
         self.new_cases = self.clone_cases()
-        # self.analysis_type = self.get_analysis_type()
-        # if self.metawf_uuid:
-        #    self.meta_wfr = self.add_metawfr()
+        self.analysis_type = self.get_analysis_type()
+        if self.metawf_uuid and self.analysis_type:
+           self.meta_wfr = self.add_metawfr()
 
     def append_version_to_value(self, value, pretty=False):
         if value is None:
@@ -195,6 +195,8 @@ class CaseToClone:
     def get_analysis_type(self):
         # figure out if analysis will be trio or proband only or proband-only cram
         sp_type = self.sp_metadata.get('analysis_type', '')
+        if not sp_type or not sp_type.startswith('WGS'):
+            return None
         if sp_type.endswith('Trio'):
             return 'trio'
         elif sp_type.endswith('Group'):
@@ -208,15 +210,23 @@ class CaseToClone:
         return 'proband'
 
     def add_metawfr(self):
-        metawfr_json = import_metawfr.import_metawfr(
+        metawfr_json = create_metawfr.create_metawfr_from_case(
             metawf_uuid=self.metawf_uuid,
-            metawfr_uuid=self.case_metadata['meta_workflow_run'],
             case_uuid=self.case_metadata['uuid'],
-            steps_name=self.steps_to_rerun,
-            create_metawfr=create_metawfr.create_metawfr_from_case,
             type=f'WGS {self.analysis_type}',
             ff_key=self.key,
-            post=False,
-            verbose=False
-        )
+            post=True,
+            patch_case=True,
+            verbose=False)
+        # metawfr_json = import_metawfr.import_metawfr(
+        #     metawf_uuid=self.metawf_uuid,
+        #     metawfr_uuid=self.case_metadata['meta_workflow_run'],
+        #     case_uuid=self.case_metadata['uuid'],
+        #     steps_name=self.steps_to_rerun,
+        #     create_metawfr=create_metawfr.create_metawfr_from_case,
+        #     type=f'WGS {self.analysis_type}',
+        #     ff_key=self.key,
+        #     post=False,
+        #     verbose=False
+        # )
         return metawfr_json

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -1219,19 +1219,43 @@ def queue_variants_to_update_genelist(connection, **kwargs):
 def get_metadata_for_cases_to_clone(connection, **kwargs):
     """
     """
+    # TODO: implement steps_to_rerun, moving processed files
+
     check = CheckResult(connection, 'get_metadata_for_cases_to_clone')
 
     # get metawf_uuid
     accessions = kwargs.get('accessions')
     version = kwargs.get('version')
     steps_to_rerun = kwargs.get('steps_to_rerun')
+    if not accessions:
+        check.full_output = {}
+        check.summary = 'No cases to clone.'
+        check.description = check.summary
+        check.status = 'PASS'
+        return check
+    if not version:
+        check.full_output = {}
+        check.summary = 'No pipeline version specified.'
+        check.description = check.summary
+        check.status = 'ERROR'
+        return check
     if 'all' not in steps_to_rerun:
-        output = {}
+        check.full_output = {}
         check.summary = 'Specifying steps to rerun not yet supported. '
+        check.description = ('Specifying steps to rerun not yet supported. Please rerun with '
+                             'steps_to_rerun="all" and create meta-workflow run manually.')
+        check.status = 'ERROR'
+        return check
     meta_workflows = ff_utils.search_metadata(
         f'search/?type=MetaWorkflow&version={version}&field=title&field=uuid',
         key=connection.ff_keys
     )
+    if not meta_workflows:
+        check.full_output = {}
+        check.summary = 'No meta-workflows found with the specified version.'
+        check.description = check.summary
+        check.status = 'ERROR'
+        return check
     meta_workflow_dict = {mwf['title']: mwf['uuid'] for mwf in meta_workflows}
     output = {'run': {}, 'ignore': {}}
     for case in accessions:
@@ -1243,17 +1267,16 @@ def get_metadata_for_cases_to_clone(connection, **kwargs):
         updated_mwf = False
         for k, v in meta_workflow_dict.items():
             if k in mwfr:
+                # value is a dict so that we can add more metadata in future iterations 
                 output['run'][case] = {'metawf_uuid': v}
                 updated_mwf = True
                 break
         if not updated_mwf:
             output['ignore'][case] = f"{version} pipeline not found for this case's meta-workflow."
             continue
-        # figure steps to rerun?
-        if 'all' not in steps_to_rerun:
 
-
+    check.full_output = output
     check.status = 'PASS'
-    check.summary = ''
+    check.summary = f'{len(output["run"].keys())} cases ready to clone, {len(output["ignore"].keys())} cases ignored'
     check.description = check.summary
     return check


### PR DESCRIPTION
This PR adds a check and action for cloning cases. In this current version, a new meta-wfr is associated with the cloned case(s) but it will be newly created and start from scratch - i.e. we won't be able to specify a particular step to start from and clone the old meta-wfr. We intend to implement that ability in a later version after this first version is in.

get_metadata_for_cases_to_clone check:
- needs version and accessions kwargs
- looks up uuid of the metawf that should be attached to the cloned case
- case ignored if no meta-wfr already on it
- case ignored if meta-wfr on it is associated with a meta-wf that doesn't have a version specified in the kwarg (e.g., if a case has a mwfr from WGS trio v24, and v25 is the latest version of WGS trio metawf, but v26 was put in the kwarg, then this case will get ignored)
- case ignored if meta-wfr on it is already the version specified in the kwarg

clone_cases action:
- clones cases (if its a group analysis, will also clone non-proband cases)
- clones samples, creates new sample_processing
- family, individual, fastq items not duplicated but are associated properly
- new meta-wfr is created with specified version but will start from scratch