### PR TITLE
Enable Sentieon, Generic

### DIFF
--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -19,7 +19,9 @@ default_pipelines_to_run = ['CNV Germline v1', 'WGS Trio v26',
     'WGS Proband-only Cram v26', 'WES Proband-only v26', 'WES Family v26', 'WES Trio v26',
     'WGS Proband-only v26', 'WGS Family v26', 'WGS Trio v27', 'WGS Proband-only Cram v27',
     'WES Proband-only v27', 'WES Family v27', 'WES Trio v27', 'WGS Proband-only v27',
-    'WGS Family v27', 'SV Germline v3', 'WGS Upstream GATK Proband v27']
+    'WGS Family v27', 'SV Germline v3', 'WGS Upstream GATK Proband v27',
+    'WGS Upstream Sentieon Proband v27', 'WGS Somatic Sentieon v1',
+    'Generic Wolf Test Pipeline v1']
 
 
 @check_function(file_type='File', start_date=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "1.5.0"
+version = "1.5.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Adds Sentieon pipelines for auto-run 
- Adds a generic test pipeline identifier that can be used to get foursight to pick up new pipelines in testing without a deployment