### PR TITLE
Deployment Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ requirements.txt
 
 # PyCharm
 .idea/
+
+# Flake8
+.flake8

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ requirements.txt
 
 # Flake8
 .flake8
+
+# Vim
+*.swp

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1,424 +1,191 @@
 {
     "item_counts_by_type": {
         "title": "Item counts by type",
-        "group": "Metadata checks",
+        "group": "Metadata Checks",
         "schedule": {
-            "hourly_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "indexing_progress": {
         "title": "Indexing progress",
-        "group": "Elasticsearch checks",
-        "conditions": [
-            "put_env"
-        ],
+        "group": "Elasticsearch Checks",
         "schedule": {
-            "hourly_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": [
-                        "item_counts_by_type"
-                    ]
+                    }
                 }
             }
-        }
-    },
-    "elastic_beanstalk_health": {
-        "title": "Elastic Beanstalk health",
-        "group": "System checks",
-        "conditions": [
-            "put_env"
-        ],
-        "schedule": {
-            "hourly_checks": {
-                "all": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            },
-            "morning_checks": {
-                "all": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "status_of_elasticsearch_indices": {
         "title": "Status of elasticsearch indices",
-        "group": "Elasticsearch checks",
+        "group": "Elasticsearch Checks",
         "conditions": [
             "put_env"
         ],
         "schedule": {
-            "thirty_min_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "indexing_records": {
         "title": "Indexing records",
-        "group": "Elasticsearch checks",
+        "group": "Elasticsearch Checks",
         "conditions": [
             "put_env"
         ],
         "schedule": {
-            "thirty_min_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "change_in_item_counts": {
         "title": "Change in item counts",
-        "group": "Metadata checks",
+        "group": "Metadata Checks",
         "schedule": {
-            "morning_checks_2": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "page_children_routes": {
         "title": "Pages with bad routes",
-        "group": "Audit checks",
+        "group": "Audit Checks",
         "schedule": {
-            "morning_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "workflow_properties": {
         "title": "Workflows with missing or duplicate steps properties",
-        "group": "Audit checks",
+        "group": "Audit Checks",
         "schedule": {
-            "morning_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "check_validation_errors": {
         "title": "Search for Validation Errors",
-        "group": "Audit checks",
+        "group": "Audit Checks",
         "schedule": {
-            "morning_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
-    },
-    "secondary_queue_deduplication": {
-        "title": "Secondary queue deduplication",
-        "group": "System checks",
-        "schedule": {
-            "fifteen_min_checks": {
-                "all": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "workflow_run_has_deleted_input_file": {
-        "title": "WorkflowRun linked to deleted Files",
-        "group": "Metadata checks",
-        "schedule": {
-            "morning_checks": {
-                "all": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "check_suggested_enum_values": {
         "title": "Check fields with suggested enum",
-        "group": "Metadata checks",
-        "schedule": {
-            "monday_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "metawfrs_to_run": {
-        "title": "Metawfrs_to_run",
-        "group": "Pipeline checks",
-        "schedule": {
-            "fifteen_min_checks_3": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true,
-                        "queue_action": "prod"
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "metawfrs_to_checkstatus": {
-        "title": "Metawfrs to check status",
-        "group": "Pipeline checks",
-        "schedule": {
-            "fifteen_min_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true,
-                        "queue_action": "prod"
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "spot_failed_metawfrs": {
-        "title": "Spot-failed Metawfrs",
-        "group": "Pipeline checks",
-        "schedule": {
-            "fifteen_min_checks_2": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true,
-                        "queue_action": "prod"
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "failed_metawfrs": {
-        "title": "Failed Metawfrs",
-        "group": "Pipeline checks",
+        "group": "Metadata Checks",
         "schedule": {
             "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
-    },
-    "metawfrs_to_patch_samples": {
-        "title": "Metawfrs to patch samples with processed files",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks_2": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "SNV_metawfrs_to_patch_sample_processing": {
-        "title": "SNV metawfrs to patch sample processing with processed files",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks_2": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "SV_metawfrs_to_patch_sample_processing": {
-        "title": "SV metawfrs to patch sample processing with processed files",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks_2": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "metawfrs_to_check_linecount": {
-        "title": "Metawfrs to run line count qc",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "md5runCGAP_status": {
-        "title": "a) md5 runs",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true,
-                        "queue_action": "prod"
-                    },
-                    "dependencies": []
-                }
-            }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "ingest_vcf_status": {
         "title": "d) CGAP trigger VCF ingestion",
-        "group": "Pipeline checks",
+        "group": "Pipeline Checks",
         "schedule": {
             "hourly_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    },
-                    "dependencies": []
+                    }
                 }
             }
-        }
-    },
-    "check_vcf_ingestion_errors": {
-        "title": "Check VCFs for ingestion errors",
-        "group": "Pipeline checks",
-        "schedule": {
-            "morning_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "problematic_wfrs_status": {
-        "title": "x) Errored Runs",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
-    },
-    "long_running_wfrs_status": {
-        "title": "x) Long Running Runs",
-        "group": "Pipeline checks",
-        "schedule": {
-            "hourly_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "elastic_search_space": {
         "title": "ES Disk Space Check",
-        "group": "Elasticsearch checks",
+        "group": "Elasticsearch Checks",
         "schedule": {
-            "morning_checks": {
-                "all": {
+            "manual_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "elasticsearch_s3_count_diff": {
         "title": "S3/ES Check Count Differential",
-        "group": "Elasticsearch checks",
+        "group": "Elasticsearch Checks",
         "schedule": {
             "morning_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
-    "deploy_application_to_beanstalk": {
-        "title": "Deploy Version to ElasticBeanstalk",
-        "group": "Deployment Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
-    "deploy_cgap_production": {
-        "title": "Deploy CGAP-portal master to the cgap production environment",
-        "group": "Deployment Checks",
-        "schedule": {
-            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
@@ -429,28 +196,23 @@
     },
     "clean_s3_es_checks": {
         "title": "Wipe Checks Older Than One Month",
-        "group": "System checks",
-        "schedule": {},
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "wipe_cgap_build_indices": {
-        "title": "Wipe CGAP build indices",
-        "group": "System checks",
+        "group": "System Checks",
         "schedule": {
-            "morning_checks": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "<env-name>"
+        ]
     },
     "core_project_status": {
         "title": "Ensure CGAP Core project items are shared",
-        "group": "Metadata checks",
+        "group": "Metadata Checks",
         "schedule": {
             "morning_checks": {
                 "<env-name>": {
@@ -473,33 +235,21 @@
                     }
                 }
             }
-        }
-    },
-    "scale_down_elasticsearch_production": {
-        "title": "Scale down production ElasticSearch Cluster",
-        "group": "System checks",
-        "schedule": {
-            "friday_autoscaling_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
         },
         "display": [
             "<env-name>"
         ]
     },
-    "scale_up_elasticsearch_production": {
-        "title": "Scale up production ElasticSearch Cluster",
-        "group": "System checks",
+    "workflow_run_has_deleted_input_file": {
+        "title": "WorkflowRun linked to deleted Files",
+        "group": "Metadata Checks",
         "schedule": {
-            "monday_autoscaling_checks": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
-                    }
+                    },
+                    "dependencies": []
                 }
             }
         },
@@ -509,9 +259,9 @@
     },
     "update_variant_genelist": {
         "title": "Add gene lists to variants/variant samples",
-        "group": "Metadata checks",
+        "group": "Metadata Checks",
         "schedule": {
-            "evening_checks": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true,
@@ -519,6 +269,228 @@
                     }
                 }
             }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "long_running_wfrs_status": {
+        "title": "x) Long Running Runs",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "ecs_status": {
+        "title": "ECS Status",
+        "group": "ECS Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "update_ecs_application_versions": {
+        "title": "Update ECS Cluster Application Versions",
+        "group": "ECS Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "metawfrs_to_run": {
+        "title": "Metawfrs_to_run",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "fifteen_min_checks_3": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
         }
+    },
+    "metawfrs_to_checkstatus": {
+        "title": "Metawfrs to check status",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "fifteen_min_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "failed_metawfrs": {
+        "title": "Failed Metawfrs",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "fifteen_min_checks_2": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "spot_failed_metawfrs": {
+        "title": "Spot-failed Metawfrs",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "fifteen_min_checks_2": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "metawfrs_to_patch_samples": {
+        "title": "Metawfrs to patch samples with processed files",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "hourly_checks_2": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "SNV_metawfrs_to_patch_sample_processing": {
+        "title": "SNV metawfrs to patch sample processing with processed files",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "hourly_checks_2": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "SV_metawfrs_to_patch_sample_processing": {
+        "title": "SV metawfrs to patch sample processing with processed files",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "hourly_checks_2": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "metawfrs_to_check_linecount": {
+        "title": "Metawfrs to run line count qc",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "hourly_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "md5runCGAP_status": {
+        "title": "a) md5 runs",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "hourly_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "get_metadata_for_cases_to_clone": {
+        "title": "Get Clone Case Metadata",
+        "group": "Metadata Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "snapshot_rds": {
+        "title": "Snapshot RDS",
+        "group": "System Checks",
+        "schedule": {
+            "monthly_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
     }
 }

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -133,6 +133,22 @@
             "<env-name>"
         ]
     },
+    "workflow_run_has_deleted_input_file": {
+        "title": "WorkflowRun linked to deleted Files",
+        "group": "Metadata Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
     "check_suggested_enum_values": {
         "title": "Check fields with suggested enum",
         "group": "Metadata Checks",
@@ -149,184 +165,8 @@
             "<env-name>"
         ]
     },
-    "ingest_vcf_status": {
-        "title": "d) CGAP trigger VCF ingestion",
-        "group": "Pipeline Checks",
-        "schedule": {
-            "hourly_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "elastic_search_space": {
-        "title": "ES Disk Space Check",
-        "group": "Elasticsearch Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "elasticsearch_s3_count_diff": {
-        "title": "S3/ES Check Count Differential",
-        "group": "Elasticsearch Checks",
-        "schedule": {
-            "morning_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
-    "clean_s3_es_checks": {
-        "title": "Wipe Checks Older Than One Month",
-        "group": "System Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "core_project_status": {
-        "title": "Ensure CGAP Core project items are shared",
-        "group": "Metadata Checks",
-        "schedule": {
-            "morning_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true,
-                        "item_type": [
-                            "VariantSample",
-                            "Case",
-                            "Family",
-                            "Individual",
-                            "WorkflowRun",
-                            "FileFastq",
-                            "FileProcessed",
-                            "Sample",
-                            "SampleProcessing",
-                            "Report",
-                            "QualityMetric",
-                            "FilterSet"
-                        ]
-                    }
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "workflow_run_has_deleted_input_file": {
-        "title": "WorkflowRun linked to deleted Files",
-        "group": "Metadata Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "update_variant_genelist": {
-        "title": "Add gene lists to variants/variant samples",
-        "group": "Metadata Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true,
-                        "queue_action": "prod"
-                    }
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "long_running_wfrs_status": {
-        "title": "x) Long Running Runs",
-        "group": "Pipeline Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "ecs_status": {
-        "title": "ECS Status",
-        "group": "ECS Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
-    "update_ecs_application_versions": {
-        "title": "Update ECS Cluster Application Versions",
-        "group": "ECS Checks",
-        "schedule": {
-            "manual_checks": {
-                "<env-name>": {
-                    "kwargs": {
-                        "primary": true
-                    },
-                    "dependencies": []
-                }
-            }
-        },
-        "display": [
-            "<env-name>"
-        ]
-    },
     "metawfrs_to_run": {
-        "title": "Metawfrs_to_run",
+        "title": "Metawfrs to run",
         "group": "Pipeline Checks",
         "schedule": {
             "fifteen_min_checks_3": {
@@ -355,8 +195,8 @@
             }
         }
     },
-    "failed_metawfrs": {
-        "title": "Failed Metawfrs",
+    "spot_failed_metawfrs": {
+        "title": "Spot-failed Metawfrs",
         "group": "Pipeline Checks",
         "schedule": {
             "fifteen_min_checks_2": {
@@ -370,15 +210,14 @@
             }
         }
     },
-    "spot_failed_metawfrs": {
-        "title": "Spot-failed Metawfrs",
+    "failed_metawfrs": {
+        "title": "Failed Metawfrs",
         "group": "Pipeline Checks",
         "schedule": {
-            "fifteen_min_checks_2": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
-                        "primary": true,
-                        "queue_action": "prod"
+                        "primary": true
                     },
                     "dependencies": []
                 }
@@ -446,10 +285,25 @@
         }
     },
     "md5runCGAP_status": {
-        "title": "a) md5 runs",
+        "title": "MD5 runs",
         "group": "Pipeline Checks",
         "schedule": {
             "hourly_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "ingest_vcf_status": {
+        "title": "Trigger VCF ingestion",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
@@ -457,11 +311,78 @@
                     "dependencies": []
                 }
             }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "check_vcf_ingestion_errors": {
+        "title": "Check VCFs for ingestion errors",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "long_running_wfrs_status": {
+        "title": "Long Running Runs",
+        "group": "Pipeline Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "elastic_search_space": {
+        "title": "ES Disk Space Check",
+        "group": "Elasticsearch Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "elasticsearch_s3_count_diff": {
+        "title": "S3/ES Check Count Differential",
+        "group": "Elasticsearch Checks",
+        "schedule": {
+            "morning_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
         }
     },
-    "get_metadata_for_cases_to_clone": {
-        "title": "Get Clone Case Metadata",
-        "group": "Metadata Checks",
+    "clean_s3_es_checks": {
+        "title": "Wipe Checks Older Than One Month",
+        "group": "System Checks",
         "schedule": {
             "manual_checks": {
                 "<env-name>": {
@@ -481,6 +402,105 @@
         "group": "System Checks",
         "schedule": {
             "monthly_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "core_project_status": {
+        "title": "Ensure CGAP Core project items are shared",
+        "group": "Metadata Checks",
+        "schedule": {
+            "morning_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod",
+                        "item_type": [
+                            "VariantSample",
+                            "Case",
+                            "Family",
+                            "Individual",
+                            "WorkflowRun",
+                            "FileFastq",
+                            "FileProcessed",
+                            "Sample",
+                            "SampleProcessing",
+                            "Report",
+                            "QualityMetric",
+                            "FilterSet"
+                        ]
+                    }
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "update_variant_genelist": {
+        "title": "Add gene lists to variants/variant samples",
+        "group": "Metadata Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    }
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "get_metadata_for_cases_to_clone": {
+        "title": "Get Clone Case Metadata",
+        "group": "Metadata Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "ecs_status": {
+        "title": "ECS Status",
+        "group": "ECS Checks",
+        "schedule": {
+            "manual_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "update_ecs_application_versions": {
+        "title": "Update ECS Cluster Application Versions",
+        "group": "ECS Checks",
+        "schedule": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -89,7 +89,7 @@
         "title": "Pages with bad routes",
         "group": "Audit Checks",
         "schedule": {
-            "manual_checks": {
+            "monthly_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
@@ -121,7 +121,7 @@
         "title": "Search for Validation Errors",
         "group": "Audit Checks",
         "schedule": {
-            "manual_checks": {
+            "monthly_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
@@ -371,7 +371,7 @@
         "title": "S3/ES Check Count Differential",
         "group": "Elasticsearch Checks",
         "schedule": {
-            "morning_checks": {
+            "monthly_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
@@ -402,6 +402,23 @@
         "group": "System Checks",
         "schedule": {
             "monthly_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
+    "secondary_queue_deduplication": {
+        "title": "Secondary queue deduplication",
+        "group": "System Checks",
+        "schedule": {
+            "manual_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true
@@ -446,10 +463,10 @@
         ]
     },
     "update_variant_genelist": {
-        "title": "Add gene lists to variants/variant samples",
+        "title": "Add gene lists to variant samples",
         "group": "Metadata Checks",
         "schedule": {
-            "manual_checks": {
+            "morning_checks": {
                 "<env-name>": {
                     "kwargs": {
                         "primary": true,

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -5,7 +5,9 @@
         "schedule": {
             "hourly_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -14,12 +16,18 @@
     "indexing_progress": {
         "title": "Indexing progress",
         "group": "Elasticsearch checks",
-        "conditions": ["put_env"],
+        "conditions": [
+            "put_env"
+        ],
         "schedule": {
             "hourly_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
-                    "dependencies": ["item_counts_by_type"]
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": [
+                        "item_counts_by_type"
+                    ]
                 }
             }
         }
@@ -27,17 +35,23 @@
     "elastic_beanstalk_health": {
         "title": "Elastic Beanstalk health",
         "group": "System checks",
-        "conditions": ["put_env"],
+        "conditions": [
+            "put_env"
+        ],
         "schedule": {
             "hourly_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             },
             "morning_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -46,11 +60,15 @@
     "status_of_elasticsearch_indices": {
         "title": "Status of elasticsearch indices",
         "group": "Elasticsearch checks",
-        "conditions": ["put_env"],
+        "conditions": [
+            "put_env"
+        ],
         "schedule": {
             "thirty_min_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -59,11 +77,15 @@
     "indexing_records": {
         "title": "Indexing records",
         "group": "Elasticsearch checks",
-        "conditions": ["put_env"],
+        "conditions": [
+            "put_env"
+        ],
         "schedule": {
             "thirty_min_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -75,7 +97,9 @@
         "schedule": {
             "morning_checks_2": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -87,7 +111,9 @@
         "schedule": {
             "morning_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -99,7 +125,9 @@
         "schedule": {
             "morning_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -111,7 +139,9 @@
         "schedule": {
             "morning_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -123,7 +153,9 @@
         "schedule": {
             "fifteen_min_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -135,7 +167,9 @@
         "schedule": {
             "morning_checks": {
                 "all": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -146,56 +180,69 @@
         "group": "Metadata checks",
         "schedule": {
             "monday_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "metawfrs_to_run" : {
+    "metawfrs_to_run": {
         "title": "Metawfrs_to_run",
         "group": "Pipeline checks",
         "schedule": {
             "fifteen_min_checks_3": {
-                "cgap": {
-                    "kwargs": {"primary": true, "queue_action": "prod"},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "metawfrs_to_checkstatus" : {
+    "metawfrs_to_checkstatus": {
         "title": "Metawfrs to check status",
         "group": "Pipeline checks",
         "schedule": {
             "fifteen_min_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true, "queue_action": "prod"},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "spot_failed_metawfrs" : {
+    "spot_failed_metawfrs": {
         "title": "Spot-failed Metawfrs",
         "group": "Pipeline checks",
         "schedule": {
             "fifteen_min_checks_2": {
-                "cgap": {
-                    "kwargs": {"primary": true, "queue_action": "prod"},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "failed_metawfrs" : {
+    "failed_metawfrs": {
         "title": "Failed Metawfrs",
         "group": "Pipeline checks",
         "schedule": {
             "manual_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -206,8 +253,10 @@
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks_2": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -218,8 +267,10 @@
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks_2": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -230,8 +281,10 @@
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks_2": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -242,32 +295,39 @@
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "md5runCGAP_status" : {
+    "md5runCGAP_status": {
         "title": "a) md5 runs",
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true, "queue_action": "prod"},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true,
+                        "queue_action": "prod"
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "ingest_vcf_status" : {
+    "ingest_vcf_status": {
         "title": "d) CGAP trigger VCF ingestion",
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
@@ -278,55 +338,65 @@
         "group": "Pipeline checks",
         "schedule": {
             "morning_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "problematic_wfrs_status" : {
+    "problematic_wfrs_status": {
         "title": "x) Errored Runs",
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "long_running_wfrs_status" : {
+    "long_running_wfrs_status": {
         "title": "x) Long Running Runs",
         "group": "Pipeline checks",
         "schedule": {
             "hourly_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true},
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
                     "dependencies": []
                 }
             }
         }
     },
-    "elastic_search_space" : {
+    "elastic_search_space": {
         "title": "ES Disk Space Check",
         "group": "Elasticsearch checks",
         "schedule": {
             "morning_checks": {
                 "all": {
-                    "kwargs" : {"primary": true}
+                    "kwargs": {
+                        "primary": true
+                    }
                 }
             }
         }
     },
-    "elasticsearch_s3_count_diff" : {
+    "elasticsearch_s3_count_diff": {
         "title": "S3/ES Check Count Differential",
         "group": "Elasticsearch checks",
-        "schedule" : {
+        "schedule": {
             "morning_checks": {
-                "cgap": {
-                    "kwargs": {"primary": true}
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    }
                 }
             }
         }
@@ -336,7 +406,7 @@
         "group": "Deployment Checks",
         "schedule": {
             "manual_checks": {
-                "cgap": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
@@ -349,7 +419,7 @@
         "group": "Deployment Checks",
         "schedule": {
             "manual_checks": {
-                "cgap": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
@@ -357,18 +427,20 @@
             }
         }
     },
-    "clean_s3_es_checks" : {
+    "clean_s3_es_checks": {
         "title": "Wipe Checks Older Than One Month",
         "group": "System checks",
         "schedule": {},
-        "display": ["cgap"]
+        "display": [
+            "<env-name>"
+        ]
     },
     "wipe_cgap_build_indices": {
         "title": "Wipe CGAP build indices",
         "group": "System checks",
         "schedule": {
-             "morning_checks": {
-                "cgap": {
+            "morning_checks": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
@@ -376,18 +448,28 @@
             }
         }
     },
-    "core_project_status":{
+    "core_project_status": {
         "title": "Ensure CGAP Core project items are shared",
         "group": "Metadata checks",
         "schedule": {
             "morning_checks": {
-                "cgap": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true,
-                        "item_type": ["VariantSample", "Case", "Family",
-                            "Individual", "WorkflowRun", "FileFastq",
-                            "FileProcessed", "Sample", "SampleProcessing",
-                            "Report", "QualityMetric", "FilterSet"]
+                        "item_type": [
+                            "VariantSample",
+                            "Case",
+                            "Family",
+                            "Individual",
+                            "WorkflowRun",
+                            "FileFastq",
+                            "FileProcessed",
+                            "Sample",
+                            "SampleProcessing",
+                            "Report",
+                            "QualityMetric",
+                            "FilterSet"
+                        ]
                     }
                 }
             }
@@ -398,35 +480,39 @@
         "group": "System checks",
         "schedule": {
             "friday_autoscaling_checks": {
-                "cgap": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
                 }
             }
         },
-        "display": ["cgap"]
+        "display": [
+            "<env-name>"
+        ]
     },
     "scale_up_elasticsearch_production": {
         "title": "Scale up production ElasticSearch Cluster",
         "group": "System checks",
         "schedule": {
             "monday_autoscaling_checks": {
-                "cgap": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true
                     }
                 }
             }
         },
-        "display": ["cgap"]
+        "display": [
+            "<env-name>"
+        ]
     },
-    "update_variant_genelist":{
+    "update_variant_genelist": {
         "title": "Add gene lists to variants/variant samples",
         "group": "Metadata checks",
         "schedule": {
             "evening_checks": {
-                "cgap": {
+                "<env-name>": {
                     "kwargs": {
                         "primary": true,
                         "queue_action": "prod"

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -1025,6 +1025,7 @@ def add_grouped_with_file_relation(connection, **kwargs):
     action.output = action_logs
     return action
 
+
 @check_function(item_type=['VariantSample'])
 def core_project_status(connection, **kwargs):
     """
@@ -1069,6 +1070,7 @@ def core_project_status(connection, **kwargs):
                              ' {}'.format(item_type))
     return check
 
+
 @action_function()
 def share_core_project(connection, **kwargs):
     """
@@ -1101,6 +1103,7 @@ def share_core_project(connection, **kwargs):
         action.status = 'DONE'
     action.output = action_logs
     return action
+
 
 @check_function(days_back=1.02)
 def update_variant_genelist(connection, **kwargs):
@@ -1182,6 +1185,7 @@ def update_variant_genelist(connection, **kwargs):
         )
         check.description = check.summary
     return check
+
 
 @action_function()
 def queue_variants_to_update_genelist(connection, **kwargs):

--- a/chalicelib/vars.py
+++ b/chalicelib/vars.py
@@ -1,3 +1,6 @@
+from os.path import dirname, join
+
 FOURSIGHT_PREFIX = 'foursight-cgap'
 DEV_ENV = 'cgap'
 HOST = 'https://search-foursight-fourfront-ylxn33a5qytswm63z52uytgkm4.us-east-1.es.amazonaws.com'
+CHECK_SETUP_FILE = join(dirname(__file__), "check_setup.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "1.5.1"
+version = "1.6.0"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Here, we include changes to facilitate deployment with the new back-end orchestration.

Specifically, we:

- Replace the fixed environment names in _check_setup.json_ with the variable `<env_name` expected by 4dn-cloud-infra
- Move some checks off of fixed schedule and onto manual checks (mimicking existing changes in the 4dn-cloud-infra check setup template)
- Make this repository's _check_setup.json_ available to import

4dn-cloud-infra has a [corresponding PR](https://github.com/4dn-dcic/4dn-cloud-infra/pull/47) to use these changes.

Please inspect the changes to _check_setup.json_ and bring up any issues. Most of the switches to manual checks have been deployed, so if no one has been missing them they're likely okay to keep there. If any more of them can be moved there, let's do so. I did move a couple additional ones to manual checks when the actions are not queued automatically to help reduce the burden of searches on which no action is taken the vast majority of the time.

The current version here is not an exact match of the [currently deployed template](https://github.com/4dn-dcic/4dn-cloud-infra/blob/master/check_setup.template.json) either, as some actions that should be queued automatically (in my opinion) were not queued as such there and some checks were dropped in that file that are included here.

**Note**: All tests are currently failing, due to the old CGAP prod foursight being spun down (?). Not sure if I should just remove these tests or try to mock/refactor out the failing elements, but the latter is going to take awhile to do correctly for questionable gain. Perhaps I could set the connection to the new devtest environment instead, but not sure if that's feasible either.