### PR TITLE
Lifecycle management fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,14 @@ foursight-cgap
 Change Log
 ----------
 
+2.1.2
+=====
+* Assign correct action status when patch_file_lifecycle_status fails.
+
 2.1.1
 =====
-* Move lifecycle checks to separate group in UI
-* Automatically run action for lifecycle checks
+* Move lifecycle checks to separate group in UI.
+* Automatically run action for lifecycle checks.
 
 2.1.0
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,7 @@ Change Log
 
 2.1.3
 =====
-* Lifecycle management: If a file cannot be found on S3 (e.g. has the status ``to_be_uploaded_by_workflow``), set its status to ``deleted``.
-* Lifecycle management: Only check files with ``project.lifecycle_management_active=true``.
+* Lifecycle management: Only check files with ``project.lifecycle_management_active=true``. Furthermore, exclude files with status ``uploading`` and ``to be uploaded by workflow`` from the check.
 
 2.1.2
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight-cgap
 Change Log
 ----------
 
+2.1.3
+=====
+* Lifecycle management: If a file cannot be found on S3 (e.g. has the status ``to_be_uploaded_by_workflow``), set its status to ``deleted``.
+* Lifecycle management: Only check files with ``project.lifecycle_management_active=true``.
+
 2.1.2
 =====
 * Assign correct action status when patch_file_lifecycle_status fails.

--- a/chalicelib/checks/helpers/lifecycle_utils.py
+++ b/chalicelib/checks/helpers/lifecycle_utils.py
@@ -83,6 +83,7 @@ def check_file_lifecycle_status(
 
     search_query_base = (
         "/search/?type=File"
+        "&project.lifecycle_management_active=true"
         "&s3_lifecycle_category%21=No+value"
         f"&s3_lifecycle_category%21={IGNORE}"
         f"&date_created.to={threshold_date_fca}"
@@ -190,6 +191,7 @@ def check_deleted_files_lifecycle_status(num_files_to_check, check_after, my_aut
 
     search_query = (
         "/search/?type=File"
+        "&project.lifecycle_management_active=true"
         f"&s3_lifecycle_status%21={DELETED}"
         f"&last_modified.date_modified.to={threshold_date}"
         f"&status={DELETED}"

--- a/chalicelib/checks/helpers/lifecycle_utils.py
+++ b/chalicelib/checks/helpers/lifecycle_utils.py
@@ -84,6 +84,8 @@ def check_file_lifecycle_status(
     search_query_base = (
         "/search/?type=File"
         "&project.lifecycle_management_active=true"
+        "&status%21=uploading"
+        "&status%21=to+be+uploaded+by+workflow"
         "&s3_lifecycle_category%21=No+value"
         f"&s3_lifecycle_category%21={IGNORE}"
         f"&date_created.to={threshold_date_fca}"

--- a/chalicelib/checks/lifecycle_checks.py
+++ b/chalicelib/checks/lifecycle_checks.py
@@ -95,7 +95,6 @@ def patch_file_lifecycle_status(connection, **kwargs):
         ):
             file_bucket = raw_bucket
 
-
         try:
             s3_tag = lifecycle_utils.lifecycle_status_to_s3_tag(new_lifecycle_status)
 

--- a/chalicelib/checks/lifecycle_checks.py
+++ b/chalicelib/checks/lifecycle_checks.py
@@ -143,7 +143,7 @@ def patch_file_lifecycle_status(connection, **kwargs):
     if action_logs["error"] == []:
         action.status = "DONE"
     else:
-        action.status = "ERROR"
+        action.status = "FAIL"
     return action
 
 

--- a/chalicelib/checks/lifecycle_checks.py
+++ b/chalicelib/checks/lifecycle_checks.py
@@ -95,6 +95,7 @@ def patch_file_lifecycle_status(connection, **kwargs):
         ):
             file_bucket = raw_bucket
 
+
         try:
             s3_tag = lifecycle_utils.lifecycle_status_to_s3_tag(new_lifecycle_status)
 

--- a/chalicelib/checks/lifecycle_checks.py
+++ b/chalicelib/checks/lifecycle_checks.py
@@ -110,8 +110,8 @@ def patch_file_lifecycle_status(connection, **kwargs):
                 )
             else:
                 action_logs["logs"].append(f"Cannot tag file {uuid}: not found on S3")
-                # In this case, set everything to 'deleted' in the metadata
-                new_lifecycle_status = lifecycle_utils.DELETED
+                # In this case, keep the old lifecycle status but update the "last checked" property
+                new_lifecycle_status = old_lifecycle_status
 
             if not is_extra_file:
                 today = datetime.date.today().strftime("%Y-%m-%d")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "2.1.2"
+version = "2.1.3.1b1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "2.1.1"
+version = "2.1.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "2.1.3.1b1"
+version = "2.1.3.1b3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-cgap"
-version = "2.1.3.1b3"
+version = "2.1.3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- If a file cannot be found on S3 (e.g. has the status `to_be_uploaded_by_workflow`), set its status to `deleted`. Otherwise it will be checked forever. Note that the file at this point is at least 2 weeks old and it's unlikely that it will be ever uploaded to S3.
- Only check those files whose project has lifecycle management enabled.
- Minor refactoring