### PR TITLE
fix: update git Lambda layer to git-lambda2:8 to remediate CVEs

### DIFF
--- a/.chalice/deployed.json
+++ b/.chalice/deployed.json
@@ -38,7 +38,7 @@
       "api_gateway_stage": "api",
       "region": "us-east-1",
       "layers": [
-        "arn:aws:lambda:us-east-1:553035198032:layer:git:11"
+        "arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8"
       ]
     },
     "dev": {
@@ -68,7 +68,7 @@
       "api_gateway_stage": "api",
       "region": "us-east-1",
       "layers": [
-        "arn:aws:lambda:us-east-1:553035198032:layer:git:11"
+        "arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8"
       ]
     }
 }

--- a/.github/workflows/main-CI.yml
+++ b/.github/workflows/main-CI.yml
@@ -53,7 +53,7 @@ jobs:
           echo "{\"repo\": \"https://github.com/${{ github.repository }}\", \"ref\": \"${GITHUB_REF}\", \"branch\": \"${GITHUB_REF##*/}\", \"commit\": \"${GITHUB_SHA}\"}" > chalicelib_cgap/gitinfo.json
 
       - name: Upload the gitinfo.json file as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gitinfo
           path: chalicelib_cgap/gitinfo.json


### PR DESCRIPTION
Updates the Git Lambda layer ARN from git:11 to git-lambda2:8 (lambci) across affected Lambda functions to remediate three known Git vulnerabilities.
Old ARN:
arn:aws:lambda:us-east-1:553035198032:layer:git:11
New ARN:
arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8
CVEs Addressed

https://github.com/advisories/GHSA-wx8f-p63x-543f
CVE-2023-23946
https://github.com/advisories/GHSA-8r9w-64qj-m6cj

No application code changes. Layer swap only. The git-lambda2 layer is compatible with Python 3.10.

NOTE:
CI_Build fails because of expired Access Key Credentials. Switching to OIDC should solve this?